### PR TITLE
Add assertions to check that filepaths are valid

### DIFF
--- a/src/main/java/gray/Constants.java
+++ b/src/main/java/gray/Constants.java
@@ -1,5 +1,8 @@
 package gray;
 
+import java.io.File;
+import java.nio.file.Paths;
+
 /**
  * Contains global constants values.
  */
@@ -11,4 +14,20 @@ public class Constants {
 
     // Non-resource files
     public static final String FILEPATH_DATA_TASKS = "./data/saveTasks";
+
+    public static void main(String[] args) {
+        // Alternative to check if file paths are valid (for essential files)
+        assert checkFileExists(FILEPATH_VIEW_MAIN_WINDOW, true);
+        assert checkFileExists(FILEPATH_IMAGE_GRAY, true);
+        assert checkFileExists(FILEPATH_IMAGE_USER, true);
+        System.out.println("All OK");
+    }
+
+    private static boolean checkFileExists(String filepath, boolean isResource) {
+        if (isResource) {
+            filepath = Paths.get("./src/main/resources", filepath).toString();
+        }
+        File file = new File(filepath);
+        return file.isFile();
+    }
 }

--- a/src/main/java/gray/gui/MainWindow.java
+++ b/src/main/java/gray/gui/MainWindow.java
@@ -4,10 +4,8 @@ import static gray.Constants.FILEPATH_VIEW_MAIN_WINDOW;
 
 import java.io.IOException;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import gray.Main;
-import gray.gui.DialogBox;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;


### PR DESCRIPTION
There is no way to automatically check if filepaths (especially resource files) provided in Constants.java are valid or existent.

Therefore, validating these files need to be done
manually, otherwise the validity of these filepaths are left unknown until runtime.

Thus, provide a function that automates these checks (implemented in the main function of Constants.java).

As this is the only validation done by Constants.java, it is adequate and convenient to execute the check through the main function of Constants.java.