### PR TITLE
Refactor method names

### DIFF
--- a/src/main/java/gray/Tasks.java
+++ b/src/main/java/gray/Tasks.java
@@ -27,7 +27,7 @@ public class Tasks {
     private void save() {
         saveFile.getParentFile().mkdirs();
         try {
-            Utility.serialise(saveFile, tasks);
+            Utility.serialize(saveFile, tasks);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -39,7 +39,7 @@ public class Tasks {
             return;
         }
         try {
-            ArrayList<Task> taskList = (ArrayList<Task>) Utility.deserialise(saveFile);
+            ArrayList<Task> taskList = (ArrayList<Task>) Utility.deserialize(saveFile);
             tasks.clear();
             tasks.addAll(taskList);
         } catch (IOException | ClassNotFoundException e) {

--- a/src/main/java/gray/Utility.java
+++ b/src/main/java/gray/Utility.java
@@ -15,13 +15,13 @@ import java.io.Serializable;
 public class Utility {
 
     /**
-     * Serialises the object to the file.
+     * Serializes the object to the file.
      *
      * @param file
      * @param obj
      * @throws IOException
      */
-    public static void serialise(File file, Serializable obj) throws IOException {
+    public static void serialize(File file, Serializable obj) throws IOException {
         FileOutputStream f = new FileOutputStream(file);
         ObjectOutput s = new ObjectOutputStream(f);
         s.writeObject(obj);
@@ -31,14 +31,14 @@ public class Utility {
     }
 
     /**
-     * Deserialises an object from the file.
+     * Deserializes an object from the file.
      *
      * @param file
      * @return
      * @throws IOException
      * @throws ClassNotFoundException
      */
-    public static Object deserialise(File file) throws IOException, ClassNotFoundException {
+    public static Object deserialize(File file) throws IOException, ClassNotFoundException {
         FileInputStream in = new FileInputStream(file);
         ObjectInputStream s = new ObjectInputStream(in);
         Object obj = s.readObject();

--- a/src/test/java/gray/UtilityTest.java
+++ b/src/test/java/gray/UtilityTest.java
@@ -13,7 +13,7 @@ public class UtilityTest {
     @Test
     public void serialise_badFile_exceptionThrown() {
         try {
-            Utility.serialise(new File("./awd/awd/awd"), new Serializable() {});
+            Utility.serialize(new File("./awd/awd/awd"), new Serializable() {});
             fail();
         } catch (IOException e) {
             assertEquals("./awd/awd/awd (No such file or directory)", e.getMessage());
@@ -23,7 +23,7 @@ public class UtilityTest {
     @Test
     public void deserialise_badFile_exceptionThrown() {
         try {
-            Utility.deserialise(new File("./awd/awd/awd"));
+            Utility.deserialize(new File("./awd/awd/awd"));
             fail();
         } catch (IOException e) {
             assertEquals("./awd/awd/awd (No such file or directory)", e.getMessage());


### PR DESCRIPTION
Some method names are in British english.

I think that they should be in American english, for standardization
purposes, as most (if not all) java utils libraries uses American
spellings.

Thus, refactor and rename these method names that has British spellings
into their correspounding American spellings.

It is done this way for standardization purposes.