### PR TITLE
Refactor loops to stream for list command

### DIFF
--- a/src/main/java/gray/Tasks.java
+++ b/src/main/java/gray/Tasks.java
@@ -3,7 +3,9 @@ package gray;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 import java.util.stream.Collectors;
 
 import gray.task.Task;

--- a/src/main/java/gray/command/ListCommand.java
+++ b/src/main/java/gray/command/ListCommand.java
@@ -1,6 +1,7 @@
 package gray.command;
 
-import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import gray.Tasks;
 
@@ -17,10 +18,8 @@ public class ListCommand implements Command {
      */
     @Override
     public String execute(Tasks tasks) {
-        StringJoiner joiner = new StringJoiner("\n");
-        for (int i = 0; i < tasks.size(); i++) {
-            joiner.add(String.format("%d. %s", i + 1, tasks.get(i)));
-        }
-        return joiner.toString();
+        return IntStream.range(0, tasks.size())
+                .mapToObj(i -> String.format("%d. %s", i + 1, tasks.get(i)))
+                .collect(Collectors.joining("\n"));
     }
 }


### PR DESCRIPTION
The current implementation of the list command to generate the display
string of the task list uses a for loop.

The for loop implementation requires the explicit use of a StringJoiner
and requires explicit management of how the strings are joined.

Refactor the loop to use java streams instead.

The resultant code that uses the stream is simplier (in my opinion),
without the explicit use of StringJoiner and explict adding of strings
to the StringJoiner object. Rather, an alternate approach to declare
that these stream of strings are to be joined together via the
`Stream.collect` and `Collectors.joining` methods.